### PR TITLE
Updated ReadMe to add a commit to kickstart github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,3 @@ Copyright © 2022 [Will Jaw](https://github.com/jjaw).<br />
 This project is [Apache-2.0](LICENSE) licensed.
 
 ---
-


### PR DESCRIPTION
Github actions stopped due to the lack of activity in the past 60 days. As a quick fix, removed the random space character in the readme to kickstart the actions again.